### PR TITLE
chore: Add cspell new words 'webp' to stop ci fail

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
   "words": [
     "bmunozg",
     "nofilter",
-    "nvmrc"
+    "nvmrc",
+    "webp"
   ]
 }


### PR DESCRIPTION
Add new word 'webp' for cspell to prevent CI fail